### PR TITLE
update pulumi-equinix dependency and improve CloudRouterPeerConfig

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_equinix==0.6.0
+pulumi_equinix>=0.7.2
 pulumi_google_native>=0.32.0
 google-cloud-compute>=1.15.0


### PR DESCRIPTION
- Update pulumi_equinix to 0.7.2
- Improve CloudRouterPeerConfig by adding a retry loop to make sure the gcp router returns updated information, as it sometimes fails returning empty values